### PR TITLE
allow activesupport 4.2.2 since 4.2.1 had XSS and DoS vulnerabilities

### DIFF
--- a/dor-workflow-service.gemspec
+++ b/dor-workflow-service.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(spec)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "activesupport", '>= 3.2.1', '< 4.2.2'
+  gem.add_dependency "activesupport", '>= 3.2.1', '< 4.2.3'
   gem.add_dependency "nokogiri", '~> 1.6.0'
-  gem.add_dependency "rest-client", '~> 1.6.7'
+  gem.add_dependency "rest-client", '~> 1.7'
   gem.add_dependency "confstruct", '~> 0.2.7'
 
   gem.add_development_dependency "rake"

--- a/lib/dor/workflow_version.rb
+++ b/lib/dor/workflow_version.rb
@@ -1,7 +1,7 @@
 module Dor
   module Workflow
     module Service
-      VERSION = "1.7.4"
+      VERSION = "1.7.5"
     end
   end
 end


### PR DESCRIPTION
i had to update this to update argo to pass the bundle-audit check for deployment.  hopefully these minor dependency relaxations are acceptable.  unit tests passed for me on my laptop.