### PR TITLE
Place default logdev into log/workflow_services.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ _yardoc
 coverage
 doc/
 lib/bundler/man
+log/
 pkg
 rdoc
 spec/reports

--- a/lib/dor/services/workflow_service.rb
+++ b/lib/dor/services/workflow_service.rb
@@ -437,7 +437,11 @@ module Dor
       # @param [String, IO] logdev The log device. This is a filename (String) or IO object (typically STDOUT, STDERR, or an open file).
       # @param [String, Integer] shift_age Number of old log files to keep, or frequency of rotation (daily, weekly or monthly).
       # @return [Logger] default logger object
-      def default_logger(logdev = 'workflow_service.log', shift_age = 'weekly')
+      def default_logger(logdev = nil, shift_age = 'weekly')
+        logdev ||= begin
+          FileUtils.mkdir('log')
+          logdev = 'log/workflow_service.log'
+        end
         Logger.new(logdev, shift_age)
       end
 


### PR DESCRIPTION
Keep the `default_logger` method and allow it to create a `log/workflow_service.log` file.  To merge into `develop`, call the `default_logger` method in this branch instead of the one-liner.