### PR TITLE
Adds support for HTTP persistent connections

### DIFF
--- a/dor-workflow-service.gemspec
+++ b/dor-workflow-service.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rest-client', '~> 1.7'
   gem.add_dependency 'retries'
   gem.add_dependency 'confstruct', '>= 0.2.7', '< 2'
+  gem.add_dependency 'faraday', '~> 0.9.2'
+  gem.add_dependency 'net-http-persistent', '~> 2.9.4'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3.3'


### PR DESCRIPTION
This PR implements HTTP persistent connections for the workflow service client. It uses Faraday and the net-http-persistent gems, and only implements persistent connections on the `GET` methods.

Note that you need to ensure that you do not have an oldish version of `webmock` running as it will disable the persistent connections.

Testing is a little tricky but I changed the Apache log output format to include `k=%k %{Keep-Alive}o` -- the `%k` shows which of the n-th requests this is on the same connection, and a successful log trace looks like so:

```
[30/Nov/2015:15:23:32 -0800] "GET /workflow/dor/objects/druid:kv840rx2720/workflows/ HTTP/1.1" 200 2297 k=0 timeout=5, max=100
[30/Nov/2015:15:23:32 -0800] "GET /workflow/dor/objects/druid:kv840rx2720/lifecycle HTTP/1.1" 200 121 k=1 timeout=5, max=99
[30/Nov/2015:15:23:32 -0800] "GET /workflow/dor/objects/druid:kv840rx2720/lifecycle HTTP/1.1" 200 121 k=2 timeout=5, max=98
[30/Nov/2015:15:23:32 -0800] "GET /workflow/dor/objects/druid:kv840rx2720/lifecycle HTTP/1.1" 200 121 k=3 timeout=5, max=97
```