### PR TITLE
Remove rest-client dependency, instead use Faraday for all request types

### DIFF
--- a/dor-workflow-service.gemspec
+++ b/dor-workflow-service.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'activesupport', '>= 3.2.1', '< 5'
   gem.add_dependency 'nokogiri', '~> 1.6.0'
-  gem.add_dependency 'rest-client', '~> 1.7'
   gem.add_dependency 'retries'
   gem.add_dependency 'confstruct', '>= 0.2.7', '< 2'
   gem.add_dependency 'faraday', '~> 0.9.2'


### PR DESCRIPTION
Using two different HTTP clients in a single gem seems strange.