### PR TITLE
Fix for broken count_*_for_workstep APIs

### DIFF
--- a/dor-workflow-service.gemspec
+++ b/dor-workflow-service.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'yard'
   gem.add_development_dependency 'redcarpet'
   gem.add_development_dependency 'equivalent-xml', '~> 0.5.1'
+  gem.add_development_dependency 'simplecov'
 end

--- a/lib/dor/services/workflow_service.rb
+++ b/lib/dor/services/workflow_service.rb
@@ -321,7 +321,7 @@ module Dor
       #
       # @return [Integer] Number of objects with this repository:workflow:step that have a status of 'error'
       def count_errored_for_workstep(workflow, step, repository = 'dor')
-        count_objects_in_step(workflow, step, repository, 'error')
+        count_objects_in_step(workflow, step, 'error', repository)
       end
 
       # Returns the number of objects that have a status of 'queued' in a particular workflow and step
@@ -332,7 +332,7 @@ module Dor
       #
       # @return [Integer] Number of objects with this repository:workflow:step that have a status of 'queued'
       def count_queued_for_workstep(workflow, step, repository = 'dor')
-        count_objects_in_step(workflow, step, repository, 'queued')
+        count_objects_in_step(workflow, step, 'queued', repository)
       end
 
       # Gets all of the workflow steps that have a status of 'queued' that have a last-updated timestamp older than the number of hours passed in

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,11 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'simplecov'
+SimpleCov.start do
+  add_filter 'spec'
+end
+
 require 'dor-workflow-service'
 require 'equivalent-xml'
 require 'equivalent-xml/rspec_matchers'


### PR DESCRIPTION
This PR fixes `count_errored_for_workstep` and `count_queued_for_workstep` which had transposed arguments. I also increased the code coverage and added `simplecov`.