### PR TITLE
Wrap HTTP client errors in a Dor::WorkflowException class

### DIFF
--- a/lib/dor/services/workflow_service.rb
+++ b/lib/dor/services/workflow_service.rb
@@ -432,6 +432,12 @@ module Dor
         @@http_conn
       end
 
+      ##
+      # Get the configured URL for the connection
+      def base_url
+        workflow_resource.url_prefix
+      end
+
       # Among other things, a distinct method helps tests mock default logger
       # @param [String, IO] logdev The log device. This is a filename (String) or IO object (typically STDOUT, STDERR, or an open file).
       # @param [String, Integer] shift_age Number of old log files to keep, or frequency of rotation (daily, weekly or monthly).
@@ -528,7 +534,7 @@ module Dor
       # @return [Object] response from method
       def workflow_resource_method(uri_string, meth = 'get', payload = '', opts = {})
         with_retries(:max_tries => 2, :handler => @@handler, :rescue => workflow_service_exceptions_to_catch) do |attempt|
-          @@logger.info "[Attempt #{attempt}] #{meth} #{workflow_resource.url_prefix}/#{uri_string}"
+          @@logger.info "[Attempt #{attempt}] #{meth} #{base_url}/#{uri_string}"
 
           response = workflow_resource.send(meth, uri_string) do |req|
             req.body = payload unless meth == 'delete'

--- a/lib/dor/workflow_exception.rb
+++ b/lib/dor/workflow_exception.rb
@@ -1,0 +1,4 @@
+module Dor
+  class WorkflowException < ::RuntimeError
+  end
+end

--- a/spec/workflow_service_spec.rb
+++ b/spec/workflow_service_spec.rb
@@ -74,7 +74,7 @@ describe Dor::WorkflowService do
 
     it 'should log an error and retry upon a targetted Faraday exception' do
       expect(@mock_logger).to receive(:warn).with(/\[Attempt 1\] Faraday::ClientError: the server responded with status 418/)
-      expect { Dor::WorkflowService.create_workflow(@repo, @druid, 'httpException', wf_xml) }.to raise_error Faraday::ClientError
+      expect { Dor::WorkflowService.create_workflow(@repo, @druid, 'httpException', wf_xml) }.to raise_error Dor::WorkflowException
     end
 
     it 'should raise on an unexpected Exception' do
@@ -128,7 +128,7 @@ describe Dor::WorkflowService do
     end
 
     it 'should return false if the PUT to the DOR workflow service throws an exception' do
-      expect{ Dor::WorkflowService.update_workflow_status(@repo, @druid, 'errorWF', 'reader-approval', 'completed') }.to raise_error(Exception, /the server responded with status 400/)
+      expect{ Dor::WorkflowService.update_workflow_status(@repo, @druid, 'errorWF', 'reader-approval', 'completed') }.to raise_error(Dor::WorkflowException, /status 400/)
     end
 
     it 'performs a conditional update when current-status is passed as a parameter' do
@@ -160,7 +160,7 @@ describe Dor::WorkflowService do
       Dor::WorkflowService.update_workflow_error_status(@repo, @druid, 'etdSubmitWF', 'reader-approval', 'Some exception', :error_text =>'The optional stacktrace')
     end
     it 'should return false if the PUT to the DOR workflow service throws an exception' do
-      expect{ Dor::WorkflowService.update_workflow_status(@repo, @druid, 'errorWF', 'reader-approval', 'completed') }.to raise_error(Exception, /the server responded with status 400/)
+      expect{ Dor::WorkflowService.update_workflow_status(@repo, @druid, 'errorWF', 'reader-approval', 'completed') }.to raise_error(Dor::WorkflowException, /status 400/)
     end
   end
 
@@ -189,10 +189,10 @@ describe Dor::WorkflowService do
       expect(Dor::WorkflowService.get_workflow_status('dor', 'druid:123', 'etdSubmitWF', 'registrar-approval')).to eq('completed')
     end
     it 'should throw an exception if it fails for any reason' do
-      expect{ Dor::WorkflowService.get_workflow_status('dor', 'druid:123', 'missingWF', 'registrar-approval') }.to raise_error Faraday::ResourceNotFound
+      expect{ Dor::WorkflowService.get_workflow_status('dor', 'druid:123', 'missingWF', 'registrar-approval') }.to raise_error Dor::WorkflowException
     end
     it 'should throw an exception if it cannot parse the response' do
-      expect{ Dor::WorkflowService.get_workflow_status('dor', 'druid:123', 'errorWF', 'registrar-approval') }.to raise_error(Exception, "Unable to parse response:\nsomething not xml")
+      expect{ Dor::WorkflowService.get_workflow_status('dor', 'druid:123', 'errorWF', 'registrar-approval') }.to raise_error(Dor::WorkflowException, "Unable to parse response:\nsomething not xml")
     end
     it 'should return nil if the workflow/process combination doesnt exist' do
       expect(Dor::WorkflowService.get_workflow_status('dor', 'druid:123', 'accessionWF', 'publish')).to be_nil


### PR DESCRIPTION
The `dor-services` is very tightly coupled to the internal workings of this class. This PR tries to provide better abstractions that we can use in `dor-services` to avoid assuming e.g. `RestClient` errors.