### PR TITLE
Add count_archived_for_workflow accessor for the number of archived workflows

### DIFF
--- a/lib/dor/services/workflow_service.rb
+++ b/lib/dor/services/workflow_service.rb
@@ -336,6 +336,16 @@ module Dor
         count_objects_in_step(workflow, step, 'queued', repository)
       end
 
+      ##
+      # Returns the number of objects that have completed a particular workflow
+      # @param [String] workflow name
+      # @param [String] repository -- optional, default=dor
+      # @return [Integer] Number of objects with this repository:workflow that have been archived
+      def count_archived_for_workflow(workflow, repository = 'dor')
+        resp = workflow_resource_method "workflow_archive?repository=#{repository}&workflow=#{workflow}&count-only=true"
+        extract_object_count(resp)
+      end
+
       # Gets all of the workflow steps that have a status of 'queued' that have a last-updated timestamp older than the number of hours passed in
       #   This will enable re-queueing of jobs that have been lost by the job manager
       # @param [String] repository name of the repository you want to query, like 'dor' or 'sdr'
@@ -521,8 +531,12 @@ module Dor
 
       def count_objects_in_step(workflow, step, type, repo)
         resp = workflow_resource_method "workflow_queue?repository=#{repo}&workflow=#{workflow}&#{type}=#{step}"
+        extract_object_count(resp)
+      end
+
+      def extract_object_count(resp)
         node = Nokogiri::XML(resp).at_xpath('/objects')
-        raise 'Unable to determine count from response' if node.nil?
+        raise Dor::WorkflowException.new('Unable to determine count from response') if node.nil?
         node['count'].to_i
       end
 

--- a/spec/workflow_service_spec.rb
+++ b/spec/workflow_service_spec.rb
@@ -442,6 +442,27 @@ describe Dor::WorkflowService do
     end
   end
 
+  describe '#count_archived_for_workflow' do
+    before(:all) do
+      @repository = 'dor'
+      @workflow   = 'accessionWF'
+    end
+
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.get("/workflow_archive?repository=#{@repository}&workflow=#{@workflow}&count-only=true") do |env|
+          [200, {}, <<-EOXML ]
+            <objects count="20" />
+            EOXML
+        end
+      end
+    end
+
+    it 'counts how many workflows are archived' do
+      expect(Dor::WorkflowService.count_archived_for_workflow(@workflow, @repository)).to eq(20)
+    end
+  end
+
   describe '#delete_workflow' do
     let(:url) { "#{@repo}/objects/#{@druid}/workflows/accessionWF" }
 


### PR DESCRIPTION
`Dor::WorkflowObject#to_solr` [1] directly accesses the workflow service REST APi. This commit moves this logic upstream.

[1] https://github.com/sul-dlss/dor-services/blob/c672c0b60a74a5b1aa72ad69885638e8b4f34456/lib/dor/models/workflow_object.rb#L48