### PR TITLE
bump nokogiri ~> 1.7

### DIFF
--- a/dor-workflow-service.gemspec
+++ b/dor-workflow-service.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'activesupport', '>= 3.2.1', '< 6'
-  gem.add_dependency 'nokogiri', '~> 1.6'
+  gem.add_dependency 'nokogiri', '~> 1.7'
   gem.add_dependency 'retries'
   gem.add_dependency 'confstruct', '>= 0.2.7', '< 2'
   gem.add_dependency 'faraday', '~> 0.9', '>= 0.9.2'

--- a/lib/dor/workflow_version.rb
+++ b/lib/dor/workflow_version.rb
@@ -1,7 +1,7 @@
 module Dor
   module Workflow
     module Service
-      VERSION = '2.2.1'
+      VERSION = '2.2.2'
     end
   end
 end


### PR DESCRIPTION
In a bundle install with no Gemfile.lock, this allowed `Using nokogiri 1.8.0`.