### PR TITLE
Release 1.8.1

### DIFF
--- a/dor-workflow-service.gemspec
+++ b/dor-workflow-service.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'activesupport', '>= 3.2.1', '< 5'
-  gem.add_dependency 'nokogiri', '~> 1.6.0'
+  gem.add_dependency 'nokogiri', '~> 1.7'
   gem.add_dependency 'rest-client', '~> 1.7'
   gem.add_dependency 'retries'
   gem.add_dependency 'confstruct', '>= 0.2.7', '< 2'

--- a/lib/dor/workflow_version.rb
+++ b/lib/dor/workflow_version.rb
@@ -1,7 +1,7 @@
 module Dor
   module Workflow
     module Service
-      VERSION = '1.8.0'
+      VERSION = '1.8.1'
     end
   end
 end


### PR DESCRIPTION
The travis builds are pulling nokogiri 1.8.0 and it might be incompatible with ruby < 2.1.x because the build matrix is failing at ruby < 2.1.x and passing for any ruby > 2.1

Can we prune the travis build matrix for for dor-workflow-service?