### PR TITLE
Remove slash in rescue message

### DIFF
--- a/lib/dor/services/workflow_service.rb
+++ b/lib/dor/services/workflow_service.rb
@@ -555,7 +555,7 @@ module Dor
           response.body
         end
       rescue *workflow_service_exceptions_to_catch => e
-        msg = "Failed to retrieve resource: #{meth} #{base_url}/#{uri_string}"
+        msg = "Failed to retrieve resource: #{meth} #{base_url}#{uri_string}"
         msg += " (HTTP status #{e.response[:status]})" if e.respond_to?(:response) && e.response
         raise Dor::WorkflowException, msg
       end


### PR DESCRIPTION
  base_url has a trailing slash already

  This will eliminate confusion around log messages such as:

  ```
[2018-08-29T15:11:40.551844 #21948] ERROR -- : Error performing MoabReplicationAuditJob (Job ID: 9fcb94a0-b431-43ae-b45e-51b993545c78) from Resque(moab_replication_audit) in 1516.2ms: Dor::WorkflowException (Failed to retrieve resource: put https://sul-lyberservices-prod.stanford.edu/workflow//dor/objects/druid:jq458kf3115/workflows/preservationAuditWF/preservation-audit (HTTP status 500)):
  ```